### PR TITLE
Add setDatabase to Jenssegers\Mongodb\Connection

### DIFF
--- a/src/Jenssegers/Mongodb/Connection.php
+++ b/src/Jenssegers/Mongodb/Connection.php
@@ -266,6 +266,16 @@ class Connection extends BaseConnection
     {
         return new Schema\Grammar();
     }
+    
+    /**
+     * Set database.
+     * @param \MongoDB\Database $db
+     */
+    public function setDatabase(\MongoDB\Database $db)
+	{
+		$this->db = $db;
+	}
+
 
     /**
      * Dynamically pass methods to the connection.


### PR DESCRIPTION
We have a use case where the database is determined dynamically and is not known in advance.
Previously, we used `DB::purge()` which wasn't ideal as this would cause the previous connection to be closed.

This change would allow us to change the database on demand.